### PR TITLE
Post-build action to make sure .SQL files are marked as Embedded Resource

### DIFF
--- a/docs/more-info/convention-check.md
+++ b/docs/more-info/convention-check.md
@@ -1,0 +1,9 @@
+It is not uncommon for developers to forget to set the Build Action 
+to `Embedded Resource`. This error can be mitigated by adding the following
+action to the post-build event in your `.csproj` file.
+
+    <Target Name="AfterBuild">
+      <Message Text="@(Content)" Importance="high" Condition="%(Content.Extension) == '.sql'" />
+      <Error Condition="%(Content.Extension) == '.sql'" 
+             Text="Nothing should be marked as Content, check your scripts are marked as Embedded Resource" />
+    </Target>

--- a/docs/more-info/convention-check.md
+++ b/docs/more-info/convention-check.md
@@ -7,3 +7,12 @@ action to the post-build event in your `.csproj` file.
       <Error Condition="%(Content.Extension) == '.sql'" 
              Text="Nothing should be marked as Content, check your scripts are marked as Embedded Resource" />
     </Target>
+
+
+You can have DbUp add this script for you via Package Manager Console
+
+    PM> Add-DbUpEmbeddedCheck -ProjectName SomeSolution.DataMigration
+
+or  alternatively, you could pick the project from the Default project dropdown, and then run
+
+    PM> Add-DbUpEmbeddedCheck

--- a/src/DbUp/dbup.nuspec
+++ b/src/DbUp/dbup.nuspec
@@ -16,5 +16,7 @@
     <file src="bin\$configuration$\DbUp.dll" target="lib\net35\" />
     <file src="bin\$configuration$\DbUp.pdb" target="lib\net35\" />
     <file src="bin\$configuration$\DbUp.xml" target="lib\net35\" />
+    <file src="..\Tools\init.ps1" target="tools" />
+    <file src="..\Tools\DbUp.psm1" target="tools" />
   </files>
 </package>

--- a/src/Tools/DbUp.psm1
+++ b/src/Tools/DbUp.psm1
@@ -1,0 +1,42 @@
+function Add-DbUpEmbeddedCheck
+{
+    param($project)
+
+    if (-Not $project) 
+    {
+        $project = Get-Project
+    }
+
+    $ProjectName = $project.Name
+
+    # Need to load MSBuild assembly if it's not loaded yet.
+    Add-Type -AssemblyName 'Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
+
+    # Grab the loaded MSBuild project for the project
+    $msbuild = [Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollection.GetLoadedProjects($project.FullName) | Select-Object -First 1
+ 
+    Write "Adding target with name DbUpCheck to $ProjectName ..."
+
+    if ($msbuild.Xml.Targets | ? { $_.Name -eq "DbUpCheck" })
+    {
+        Write "Target with name DbUpCheck already exists in $ProjectName. No action taken."
+        return
+    }
+
+    # Add a target to fail the build when our targets are not imported
+    $target = $msbuild.Xml.AddTarget("DbUpCheck")
+
+    $messageTask = $target.AddTask("Message")
+    $messageTask.SetParameter("Text", "@(Content)")
+    $messageTask.SetParameter("Importance", "high")
+    $messageTask.Condition = "%(Content.Extension) == '.sql'"
+
+    $errorTask = $target.AddTask("Error")
+    $errorTask.Condition = "%(Content.Extension) == '.sql'"
+    $errorTask.SetParameter("Text", "@(Content) is marked as content. Scripts should be marked as Embedded Resource.")
+
+    $project.Save()
+
+    Write "Added Target with name DbUp check to $ProjectName."
+
+}

--- a/src/Tools/DbUp.psm1
+++ b/src/Tools/DbUp.psm1
@@ -1,13 +1,23 @@
 function Add-DbUpEmbeddedCheck
 {
-    param($project)
+    param($ProjectName)
 
-    if (-Not $project) 
+    if ($ProjectName) 
     {
-        $project = Get-Project
+        $Project = Get-Project -Name $ProjectName
+
+        if (-Not $Project)
+        {
+            Return
+        }
+
+    }
+    else
+    {
+        $Project = Get-Project
     }
 
-    $ProjectName = $project.Name
+    $ProjectName = $Project.Name
 
     # Need to load MSBuild assembly if it's not loaded yet.
     Add-Type -AssemblyName 'Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
@@ -20,7 +30,7 @@ function Add-DbUpEmbeddedCheck
     if ($msbuild.Xml.Targets | ? { $_.Name -eq "DbUpCheck" })
     {
         Write "Target with name DbUpCheck already exists in $ProjectName. No action taken."
-        return
+        Return
     }
 
     # Add a target to fail the build when our targets are not imported
@@ -35,7 +45,7 @@ function Add-DbUpEmbeddedCheck
     $errorTask.Condition = "%(Content.Extension) == '.sql'"
     $errorTask.SetParameter("Text", "@(Content) is marked as content. Scripts should be marked as Embedded Resource.")
 
-    $project.Save()
+    $Project.Save()
 
     Write "Added Target with name DbUp check to $ProjectName."
 

--- a/src/Tools/DbUp.psm1
+++ b/src/Tools/DbUp.psm1
@@ -35,6 +35,7 @@ function Add-DbUpEmbeddedCheck
 
     # Add a target to fail the build when our targets are not imported
     $target = $msbuild.Xml.AddTarget("DbUpCheck")
+    $target.AfterTargets = "AfterBuild"
 
     $messageTask = $target.AddTask("Message")
     $messageTask.SetParameter("Text", "@(Content)")

--- a/src/Tools/init.ps1
+++ b/src/Tools/init.ps1
@@ -1,0 +1,8 @@
+param($installPath, $toolsPath, $package)
+ 
+foreach ($_ in Get-Module | ?{$_.Name -eq 'DbUp'})
+{
+    Remove-Module 'VSExtensionsModule'
+}
+      
+Import-Module (Join-Path $toolsPath DbUp.psm1)


### PR DESCRIPTION
This is not my invention, but I keep turning to this snippet in every DbUp project. Could we please keep it with the doco?
